### PR TITLE
eliminamte warning message about TOPPERS cfg

### DIFF
--- a/cfg/pass1.rb
+++ b/cfg/pass1.rb
@@ -176,7 +176,7 @@ def ReadSymvalTable
     end
 
     symvalCsv = CSV.open(symvalTableFileName,
-						{ skip_blanks: true, skip_lines: /^#/ })
+						 skip_blanks: true, skip_lines: /^#/)
     symvalCsv.each do |record|
       symbol = {}
 


### PR DESCRIPTION
This commit eliminates warning message about TOPPERS configurator
```
ruby ../cfg/cfg.rb --pass 1 --kernel asp -I. -I../include  -I../target/nucleo_f767zi_gcc -I../target/nucleo_f767zi_gcc/stm32fcube -I../arch/arm_m_gcc/stm32f7xx_stm32cube/ -I../../STM32CubeF7/Drivers/STM32F7xx_HAL_Driver/Inc -I../../STM32CubeF7/Drivers/CMSIS/Device/ST/STM32F7xx/Include -I../../STM32CubeF7/Drivers/CMSIS/Include -I../arch/arm_m_gcc/common -I../arch/gcc -I.. -I../sample -I./gen -I../tecs_kernel --api-table ../kernel/kernel_api.def --symval-table ../kernel/kernel_sym.def  --symval-table ../arch/arm_m_gcc/common/core_sym.def \
					-M objs/cfg1_out_c.d ../target/nucleo_f767zi_gcc/target_kernel.cfg ../sample/sample1.cfg
/home/takase/ros/mROS2/github/mros2-asp3-f767zi/asp3-f767zi/cfg/pass1.rb:178: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
/usr/lib/ruby/2.7.0/csv.rb:635: warning: The called method `open' is defined here
```

More info:
https://github.com/toppers/users-forum/discussions/53#discussioncomment-1855377
https://dev.toppers.jp/trac/ruby_cfg/changeset/191/